### PR TITLE
Seed default admin, sample data, and handle empty stock

### DIFF
--- a/src/main/java/com/icodeap/ecommerce/application/repository/UserRepository.java
+++ b/src/main/java/com/icodeap/ecommerce/application/repository/UserRepository.java
@@ -6,5 +6,6 @@ public interface UserRepository {
     public User createUser(User user);
     public User findByEmail(String email);
     public User findById(Integer id);
+    public boolean existsByEmail(String email);
 
 }

--- a/src/main/java/com/icodeap/ecommerce/application/service/CartService.java
+++ b/src/main/java/com/icodeap/ecommerce/application/service/CartService.java
@@ -18,35 +18,38 @@ public class CartService {
     }
 
     public void addItemCart(Integer quantity, Integer idProduct, String nameProduct, BigDecimal price){
-        ItemCart itemCart = new ItemCart(idProduct, nameProduct, quantity, price);
-        itemCartHashMap.put(itemCart.getIdProduct(), itemCart);
+        ItemCart itemCart = itemCartHashMap.get(idProduct);
+        if (itemCart != null) {
+            itemCart.setQuantity(itemCart.getQuantity() + quantity);
+        } else {
+            itemCart = new ItemCart(idProduct, nameProduct, quantity, price);
+            itemCartHashMap.put(idProduct, itemCart);
+        }
         fillList();
     }
 
-    public  BigDecimal getTotalCart(){
+    public BigDecimal getTotalCart(){
         BigDecimal total = BigDecimal.ZERO;
         for (ItemCart itemCart : itemCarts){
             total = total.add(itemCart.getTotalPriceItem());
         }
         return total;
     }
+
     public void removeItemCart(Integer idProduct){
         itemCartHashMap.remove(idProduct);
         fillList();
     }
 
     public void removeAllItemsCart(){
-        itemCartHashMap.clear();;
+        itemCartHashMap.clear();
         itemCarts.clear();
     }
 
     private void fillList(){
-        itemCarts.clear();
-        itemCartHashMap.forEach(
-                (integer, itemCart)-> itemCarts.add(itemCart)
-
-        );
+        itemCarts = new ArrayList<>(itemCartHashMap.values());
     }
+
     //para mirar por consola
     public List<ItemCart> getItemCarts(){
         return itemCarts;

--- a/src/main/java/com/icodeap/ecommerce/application/service/UploadFile.java
+++ b/src/main/java/com/icodeap/ecommerce/application/service/UploadFile.java
@@ -2,29 +2,30 @@ package com.icodeap.ecommerce.application.service;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class UploadFile {
-    private final String FOLDER = "images//";
+    private final Path folder = Paths.get("images");
     private final String IMG_DEFAULT = "default.jpg";
 
     public String upload(MultipartFile multipartFile) throws IOException {
-        if (!multipartFile.isEmpty()){
-            byte [] bytes = multipartFile.getBytes();
-            Path path = Paths.get(FOLDER + multipartFile.getOriginalFilename());
-            Files.write(path ,bytes);
+        if (!multipartFile.isEmpty()) {
+            Files.createDirectories(folder);
+            Path path = folder.resolve(multipartFile.getOriginalFilename());
+            Files.write(path, multipartFile.getBytes());
             return multipartFile.getOriginalFilename();
         }
         return IMG_DEFAULT;
     }
 
-    public void delete(String nameFile){
-        File file = new File(FOLDER + nameFile);
-        file.delete();
+    public void delete(String nameFile) {
+        try {
+            Files.deleteIfExists(folder.resolve(nameFile));
+        } catch (IOException ignored) {
+        }
     }
 
 }

--- a/src/main/java/com/icodeap/ecommerce/application/service/UserService.java
+++ b/src/main/java/com/icodeap/ecommerce/application/service/UserService.java
@@ -19,4 +19,7 @@ public class UserService {
     public User findById (Integer id){
         return userRepository.findById(id);
     }
+    public boolean existsByEmail(String email){
+        return userRepository.existsByEmail(email);
+    }
 }

--- a/src/main/java/com/icodeap/ecommerce/infrastructure/adapter/UserCrudRepository.java
+++ b/src/main/java/com/icodeap/ecommerce/infrastructure/adapter/UserCrudRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserCrudRepository extends CrudRepository<UserEntity, Integer> {
     Optional<UserEntity> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/icodeap/ecommerce/infrastructure/adapter/UserRepositoryImpl.java
+++ b/src/main/java/com/icodeap/ecommerce/infrastructure/adapter/UserRepositoryImpl.java
@@ -29,4 +29,9 @@ public class UserRepositoryImpl implements UserRepository {
     public User findById(Integer id) {
         return userMapper.toUser(userCrudRepository.findById(id).get());
     }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userCrudRepository.existsByEmail(email);
+    }
 }

--- a/src/main/java/com/icodeap/ecommerce/infrastructure/configuration/AdminUserInitializer.java
+++ b/src/main/java/com/icodeap/ecommerce/infrastructure/configuration/AdminUserInitializer.java
@@ -1,0 +1,69 @@
+package com.icodeap.ecommerce.infrastructure.configuration;
+
+import com.icodeap.ecommerce.application.repository.ProductRepository;
+import com.icodeap.ecommerce.application.repository.StockRepository;
+import com.icodeap.ecommerce.application.service.UserService;
+import com.icodeap.ecommerce.domain.Product;
+import com.icodeap.ecommerce.domain.Stock;
+import com.icodeap.ecommerce.domain.User;
+import com.icodeap.ecommerce.domain.UserType;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * Creates a default administrator account if one does not already exist.
+ */
+@Component
+public class AdminUserInitializer implements CommandLineRunner {
+    private final UserService userService;
+    private final ProductRepository productRepository;
+    private final StockRepository stockRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public AdminUserInitializer(UserService userService,
+                               ProductRepository productRepository,
+                               StockRepository stockRepository,
+                               PasswordEncoder passwordEncoder) {
+        this.userService = userService;
+        this.productRepository = productRepository;
+        this.stockRepository = stockRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public void run(String... args) {
+        String email = "admin@admin.com";
+        User admin;
+        if (!userService.existsByEmail(email)) {
+            admin = new User(null, email, "Admin", "User", email, "", "", passwordEncoder.encode("admin123"), UserType.ADMIN, LocalDateTime.now());
+            admin = userService.createUser(admin);
+        } else {
+            admin = userService.findByEmail(email);
+        }
+
+        if (!productRepository.getProducts().iterator().hasNext()) {
+            Product product = new Product();
+            product.setName("Sample Product");
+            product.setDescription("Default product");
+            product.setPrice(BigDecimal.valueOf(9.99));
+            product.setImage("default.jpg");
+            product.setDateCreated(LocalDateTime.now());
+            product.setDateUpdated(LocalDateTime.now());
+            product.setUser(admin);
+            product = productRepository.saveProduct(product);
+
+            Stock stock = new Stock();
+            stock.setDateCreated(LocalDateTime.now());
+            stock.setUnitIn(10);
+            stock.setUnitOut(0);
+            stock.setBalance(10);
+            stock.setDescription("Initial stock");
+            stock.setProduct(product);
+            stockRepository.saveStock(stock);
+        }
+    }
+}

--- a/src/main/java/com/icodeap/ecommerce/infrastructure/controller/HomeController.java
+++ b/src/main/java/com/icodeap/ecommerce/infrastructure/controller/HomeController.java
@@ -41,7 +41,7 @@ public class HomeController {
         List<Stock> stocks = stockService.getStockByProduct(productService.getProductById(id));
         log.info("Id product: {}", id);
         log.info("stock size: {}", stocks.size());
-        Integer lastBalance = stocks.get(stocks.size()-1).getBalance();
+        Integer lastBalance = stocks.isEmpty() ? 0 : stocks.get(stocks.size()-1).getBalance();
 
         model.addAttribute("product", productService.getProductById(id));
         model.addAttribute("stock", lastBalance);

--- a/src/main/resources/templates/admin/template_admin.html
+++ b/src/main/resources/templates/admin/template_admin.html
@@ -4,7 +4,7 @@
     <div class="container">
         <a class="navbar-brand" th:href="@{/admin}">Spring eCommerce</a>
 
-        <form class="form-inline my-2 my-lg-0" method="post"
+        <form class="form-inline my-2 my-lg-0" method="get"
               action="#">
             <input class="form-control mr-sm-2" type="search"
                    placeholder="Buscar" aria-label="Search" name="nombre"

--- a/src/main/resources/templates/user/template_user.html
+++ b/src/main/resources/templates/user/template_user.html
@@ -4,7 +4,7 @@
     <div class="container">
         <a class="navbar-brand" th:href="@{/home}">Spring eCommerce</a>
 
-        <form class="form-inline my-2 my-lg-0" method="post"
+        <form class="form-inline my-2 my-lg-0" method="get"
               action="#">
             <input class="form-control mr-sm-2" type="search"
                    placeholder="Buscar" aria-label="Search" name="nombre"
@@ -32,7 +32,7 @@
         <div class="container">
             <a class="navbar-brand" th:href="@{/home}">Spring eCommerce</a>
 
-            <form class="form-inline my-2 my-lg-0" method="post"
+            <form class="form-inline my-2 my-lg-0" method="get"
                   action="#">
                 <input class="form-control mr-sm-2" type="search"
                        placeholder="Buscar" aria-label="Search" name="nombre"


### PR DESCRIPTION
## Summary
- seed default admin user and attach basic product and stock records for cart/image features
- ensure image upload creates the `images` folder if missing to prevent errors
- avoid product detail crashes when a product has no stock records
- update header search forms to use GET to avoid 405 errors
- update cart service to accumulate quantities and simplify list handling

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be082a1d14832091067d0d2453cb42